### PR TITLE
bug fix for entropy column name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: foot
 Title: An R package for processing building footprint morphometrics
-Version: 0.6
-Date: 2020-11-18
+Version: 0.6.1
+Date: 2021-05-17
 Authors@R: 
 	c(person(given="WorldPop Research Group, University of Southampton", 
 			 role="aut"),

--- a/R/fs_angle_entropy.R
+++ b/R/fs_angle_entropy.R
@@ -144,7 +144,7 @@ fs_angle_entropy_calc <- function(X, index, normalize=TRUE){
   if(normalize){ # based on Boeing (2019)
     hmax <- 3.584
     hg <- 1.386
-    result[, entropy := 1 - ((entropy-hg) / (hmax - hg))^2, by=index]
+    result[, entropy := 1 - ((entropy-hg) / (hmax - hg))^2, by=indexCol]
   } 
   data.table::setnames(result, "entropy", colNam)
   


### PR DESCRIPTION
Correct the identification of a user-supplied column name in the stand-alone angle entropy calculation.
Should not have affected any calculations done with `calculate_footstats` or `calculate_bigfoot`.

closes #34