### PR TITLE
Correct invalid geometries in building footprints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,9 @@ Imports:
     units,
     filelock,
     geosphere,
-    geos
+    geos,
+    iterators,
+    mmap
 LazyData: true
 Description: Support for morphometric calculations of building footprints implemented in R. It provides flexible tools for processing 2D vector polygon representations of structures. The functionality includes basic geometry and morphology measures, distance and clustering metrics. These calculations are supported with helper functions for spatial intersections to define zonal indices and tiled reading/writing of data files.
 Encoding: UTF-8

--- a/R/calculate_pixel_footstats.R
+++ b/R/calculate_pixel_footstats.R
@@ -354,6 +354,7 @@ calc_fs_px_internal <- function(X, what, how,
   tiles <- gridTiles(template, px=tileSize)
   
   if(verbose){ 
+    cat("Number of tiles created:", nrow(tiles), "\n")
     file.create(tile_log <- file.path(outputPath, "tile.log"))
   }
   

--- a/R/calculate_pixel_footstats.R
+++ b/R/calculate_pixel_footstats.R
@@ -533,6 +533,7 @@ process_tile <- function(mgTile, mgBuffTile,
   
   #make valid
   if(any(sf::st_is_valid(Xsub) == F)){
+    if(verbose){cat('Invalid geometries found in polygons and corrected')}
     suppressWarnings(Xsub <- sf::st_make_valid(Xsub))
   }
   

--- a/R/calculate_pixel_footstats.R
+++ b/R/calculate_pixel_footstats.R
@@ -530,6 +530,11 @@ process_tile <- function(mgTile, mgBuffTile,
     suppressWarnings(Xsub <- sf::st_cast(Xsub, "POLYGON"))
   }
   
+  #make valid
+  if(any(sf::st_is_valid(Xsub) == F)){
+    suppressWarnings(Xsub <- sf::st_make_valid(Xsub))
+  }
+  
   # processing
   if(nrow(Xsub) > 0){
     # read proxy to grid and convert to polygon object


### PR DESCRIPTION
Two suggested features:
1. use `st_make_valid`
2. output in verbose mode the number of tiles used for processing